### PR TITLE
Added error handling on create payment

### DIFF
--- a/Controller/StartPayment/Index.php
+++ b/Controller/StartPayment/Index.php
@@ -91,12 +91,12 @@ class Index extends Action {
 		}
 
 		$order
-			->setPayproPaymentHash($response['payment_hash'])
+			->setPayproPaymentHash($response['return']['payment_hash'])
 			->setState(Order::STATE_PENDING_PAYMENT)
 			->setStatus(Order::STATE_PENDING_PAYMENT)
 			->save();
 
-		return $this->resultRedirectFactory->create()->setUrl($response['payment_url']);
+		return $this->resultRedirectFactory->create()->setUrl($response['return']['payment_url']);
 	}
 
 	private function getLocale() {

--- a/Controller/StartPayment/Index.php
+++ b/Controller/StartPayment/Index.php
@@ -84,6 +84,12 @@ class Index extends Action {
 			'consumer_postal' => $billingAddress->getPostcode(),
 		], $data));
 
+		if ($response['errors'] === 'true') {
+			$this->checkoutSession->restoreQuote();
+			$this->messageManager->addNoticeMessage($this->gateway->getUserFriendlyError($response['return']));
+			return $this->resultRedirectFactory->create()->setUrl('/checkout/cart');
+		}
+
 		$order
 			->setPayproPaymentHash($response['payment_hash'])
 			->setState(Order::STATE_PENDING_PAYMENT)

--- a/Plugin/Gateway.php
+++ b/Plugin/Gateway.php
@@ -40,7 +40,7 @@ class Gateway {
 	 *
 	 * @param $data
 	 *
-	 * @return bool|mixed|null
+	 * @return Array
 	 */
 	public function createPayment($data) {
 		$params = array_merge($data, [
@@ -57,10 +57,10 @@ class Gateway {
 
 		try {
 			$response = $this->client->execute();
-
-			return $response['return'];
+			if ($response['return'] === 'API key not valid') $response = array('errors' => 'true', 'return' => self::getUserFriendlyError($repsonse['return']));
+			return $response;
 		} catch (\Exception $exception) {
-			return false;
+			return array('errors' => 'true', 'return' => self::getUserFriendlyError(''));
 		}
 	}
 
@@ -102,5 +102,25 @@ class Gateway {
 		} catch (\Exception $exception) {
 			return null;
 		}
+	}
+
+	/**
+	 * change api response error to userfriendly error message
+	 *
+	 * @param responseError from api
+	 *
+	 * @return String
+	 */
+	public function getUserFriendlyError($responseError) {
+		switch ($responseError) {
+			case 'Not subscribed to money transfer service':
+				$newMessage = _('Can\'t use this payment method, please try a different method.');
+				break;
+			
+			default:
+				$newMessage = _('Something went wrong during checkout, please try again.');
+				break;
+		}
+		return $newMessage;
 	}
 }

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -4,3 +4,5 @@
 "Payment canceled, please try again.", "Payment canceled, please try again."
 "Select your bank", "Select your bank"
 "We have not received a definite payment status. Depending on the payment method, it may take a while until we receive the payment", "We have not received a definite payment status. Depending on the payment method, it may take a while until we receive the payment"
+"Can\'t use this payment method, please try a different method.", "Can\'t use this payment method, please try a different method."
+"Something went wrong during checkout, please try again.", "Something went wrong during checkout, please try again."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -4,3 +4,5 @@
 "Payment canceled, please try again.", "Betaling geannuleerd, probeer opnieuw."
 "Select your bank", "Selecteer je bank"
 "We have not received a definite payment status. Depending on the payment method, it may take a while until we receive the payment", "We hebben nog geen definitieve betaling ontvangen. Afhankelijk van de betaalmethode kan het even duren totdat we de betaling binnenkrijgen"
+"Can\'t use this payment method, please try a different method.", "Kan deze betaalmethode niet gebruiken, probeer een andere methode."
+"Something went wrong during checkout, please try again.", "Er is iets misgegaan tijdens het betalen, probeer het opnieuw."


### PR DESCRIPTION
Added error handling for some api responses instead of it going to an error page.

added redirect to cart if create payment fails with a notice message.

before:
![image](https://user-images.githubusercontent.com/55430516/141113819-cf42442c-abe5-4a60-a39f-4847402326aa.png)

after:
![image](https://user-images.githubusercontent.com/55430516/141114268-fd8ab30c-bc64-4e9e-ad6c-cc9446fac962.png)


